### PR TITLE
Set all SmallUtilities individual packs to GitHub

### DIFF
--- a/KerboKatzSmallUtilities-Afterburner.netkan
+++ b/KerboKatzSmallUtilities-Afterburner.netkan
@@ -1,9 +1,17 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KerboKatzSmallUtilities-Afterburner",
-    "$kref"        : "#/ckan/spacedock/85",
     "name"         : "KerboKatz - SmallUtilities - Afterburner",
+    "$kref"        : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.Afterburner.zip",
+    "abstract"     : "Adds thrust to stock jet engines by increasing fuel flow.",
     "license"      : "restricted",
+    "ksp_version"  : "1.0.5",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
+    "conflicts": [
+        { "name": "KerboKatzSmallUtilities" }
+    ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "KerboKatzUtilities", "min_version": "1.2.6" }

--- a/KerboKatzSmallUtilities-AutoBalancingLandingLeg.netkan
+++ b/KerboKatzSmallUtilities-AutoBalancingLandingLeg.netkan
@@ -5,8 +5,7 @@
     "name"         : "KerboKatz - SmallUtilities - AutoBalancingLandingLeg",
     "license"      : "restricted",
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
+        { "name": "ModuleManager" }
     ],
     "install": [
         {

--- a/KerboKatzSmallUtilities-DisableTempGauges.netkan
+++ b/KerboKatzSmallUtilities-DisableTempGauges.netkan
@@ -1,11 +1,16 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KerboKatzSmallUtilities-DisableTempGauges",
-    "$kref"        : "#/ckan/spacedock/85",
+    "$kref"        : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.DisableTempGauges.zip",
     "name"         : "KerboKatz - SmallUtilities - DisableTempGauges",
+    "abstract"     : "Disables Temperature gauges when you go to the flight scene. Press F10 to re-enable them.",
     "license"      : "restricted",
-    "depends": [
-        { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
+    "ksp_version"  : "1.0.5",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
+    "conflicts": [
+        { "name": "KerboKatzSmallUtilities" }
     ],
     "install": [
         {

--- a/KerboKatzSmallUtilities-EditorCamUtilities.netkan
+++ b/KerboKatzSmallUtilities-EditorCamUtilities.netkan
@@ -1,9 +1,17 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KerboKatzSmallUtilities-EditorCamUtilities",
-    "$kref"        : "#/ckan/spacedock/85",
+    "$kref"        : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.EditorCamUtilities.zip",
     "name"         : "KerboKatz - SmallUtilities - EditorCamUtilities",
+    "abstract"     : "This little tool allows you to switch between the VAB and SPH camera.",
     "license"      : "restricted",
+    "ksp_version"  : "1.0.5",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
+    "conflicts": [
+        { "name": "KerboKatzSmallUtilities" }
+    ],
     "depends": [
         { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
     ],

--- a/KerboKatzSmallUtilities-FPSLimiter.netkan
+++ b/KerboKatzSmallUtilities-FPSLimiter.netkan
@@ -6,6 +6,12 @@
     "abstract"     : "Limits the fps (frames per second) while kerbal is running in the background causing it to use less CPU & GPU cycles.",
     "license"      : "restricted",
     "ksp_version"  : "1.1",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
+    "conflicts": [
+        { "name": "KerboKatzSmallUtilities" }
+    ],
     "depends": [
         { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
     ],

--- a/KerboKatzSmallUtilities-FillSpotsWithTourists.netkan
+++ b/KerboKatzSmallUtilities-FillSpotsWithTourists.netkan
@@ -1,9 +1,17 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KerboKatzSmallUtilities-FillSpotsWithTourists",
-    "$kref"        : "#/ckan/spacedock/85",
     "name"         : "KerboKatz - SmallUtilities - FillSpotsWithTourists",
+    "$kref"        : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.FillSpotsWithTourists.zip",
+    "abstract"     : "Asks after launching if you want to fill up your free spots with tourists",
     "license"      : "restricted",
+    "ksp_version"  : "1.0.5",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
+    "conflicts": [
+        { "name": "KerboKatzSmallUtilities" }
+    ],
     "depends": [
         { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
     ],

--- a/KerboKatzSmallUtilities-ModifiedExplosionPotential.netkan
+++ b/KerboKatzSmallUtilities-ModifiedExplosionPotential.netkan
@@ -1,9 +1,17 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KerboKatzSmallUtilities-ModifiedExplosionPotential",
-    "$kref"        : "#/ckan/spacedock/85",
     "name"         : "KerboKatz - SmallUtilities - ModifiedExplosionPotential",
+    "$kref"        : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.ModifiedExplosionPotential.zip",
+    "abstract"     : "Modifies the explosion potential in order to create bigger or smaller explosions",
     "license"      : "restricted",
+    "ksp_version"  : "1.0.5",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
+    "conflicts": [
+        { "name": "KerboKatzSmallUtilities" }
+    ],
     "depends": [
         { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
     ],

--- a/KerboKatzSmallUtilities.netkan
+++ b/KerboKatzSmallUtilities.netkan
@@ -3,19 +3,11 @@
     "identifier"   : "KerboKatzSmallUtilities",
     "$kref"        : "#/ckan/spacedock/85",
     "license"      : "restricted",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104505-11-kerbokatz-smallutilities"
+    },
     "depends": [
         { "name": "KerboKatzUtilities", "min_version": "1.2.6" }
-    ],
-    "conflicts": [
-        { "name": "KerboKatzSmallUtilities-Afterburner" },
-        { "name": "KerboKatzSmallUtilities-AutoBalancingLandingLeg" },
-        { "name": "KerboKatzSmallUtilities-DisableTempGauges" },
-        { "name": "KerboKatzSmallUtilities-EditorCamUtilities" },
-        { "name": "KerboKatzSmallUtilities-FillSpotsWithTourists" },
-        { "name": "KerboKatzSmallUtilities-FPSLimiter" },
-        { "name": "KerboKatzSmallUtilities-FPSViewer" },
-        { "name": "KerboKatzSmallUtilities-ModifiedExplosionPotential" },
-        { "name": "KerboKatzSmallUtilities-PhysicalTimeRatioViewer" }
     ],
     "install": [
         {


### PR DESCRIPTION
I've also turned around the conflicts statements, so each individual pack conflicts with the complete pack, making it easier to check for missing conflicts.

I have set the ksp_version for each mod to the current release situation. As packs are moved to 1.1, all you need do is change the ksp_version when you release the new zip file, and Netkan will get the new release correct straight off.

If in the future, you wish to set a range of ksp versions, you can replace the individual "ksp_version" line with a min/max pair, like this:

```
"ksp_version_min": "1.1.0",
"ksp_version_max": "1.1.5",
```
