### PR TITLE
Get CKAN version data from version file

### DIFF
--- a/RecoverAll.netkan
+++ b/RecoverAll.netkan
@@ -6,7 +6,7 @@
     "abstract"     : "This is deprecated for KSP version 1.1 and higher. Please use KerboKatz - SmallUtilities - RecoverAll for those versions of KSP. Adds the ability to recover all landed vessels in one go.",
     "license"      : "restricted",
     "author"       : [ "SpaceTiger", "SpaceKitty" ],
-    "ksp_version"  : "1.0.5",
+    "$vref"        : "#/ckan/ksp-avc",
     "depends": [
         { "name": "KerboKatzUtilities", "min_version": "1.2.0" }
     ],


### PR DESCRIPTION
This mod contains a valid version file, which CKAN can use for compatibility info, but the metanetkan is currently not set up for this.

Now the version file will be used, which means one less place to edit when releasing.